### PR TITLE
Add instructions modal and help button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,8 @@ import { usePatterns } from "@/hooks/usePattern";
 import useCurrentBeat from "@/hooks/useCurrentBeat";
 
 import { SelectingMode } from "@/lib/utils";
-import InstructionsPaper from "@/components/InstructionsPaper/InstructionsPaper";
+import InstructionsModal from "@/components/InstructionsPaper/InstructionsModal";
+import HelpButton from "@/components/HelpButton/HelpButton";
 import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import ProductTour from "@/components/ProductTour";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
@@ -31,9 +32,6 @@ const PocketOperatorWrapper = () => {
   useEffect(() => {
     setTimeout(() => setProductTourMode((curMode) => curMode ?? "intro"), 100);
   }, [setProductTourMode]);
-
-  const showInstructionsPaper =
-    productTourMode === "finished" && (show || pinned);
 
   const {
     patterns,
@@ -116,45 +114,26 @@ const PocketOperatorWrapper = () => {
         </div>
       </div>
 
-      <div
-        style={{
-          position: "absolute",
-          width: "auto",
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "top",
-          transition: "top 0.2s ease",
-          transitionDelay: "0.25s",
-          top: showInstructionsPaper ? "26px" : "-130px",
-          ...(onTouchDevice
-            ? {}
-            : {
-                left: "2.5rem",
-                top: "2.5rem",
-                width: "10%",
-              }),
-        }}
-        onClick={(e) => {
-          e.stopPropagation();
-          setShowing(true);
-        }}
-        onMouseEnter={onTouchDevice ? undefined : () => setShowing(true)}
-      >
-        <InstructionsPaper
-          tilt={defaultTilt}
-          // if on a touch device, paper should always be expanded kinda
-          showing={show}
-          setShowing={setShowing}
-          pinned={pinned}
-          setPinned={setPinned}
-          onTouchDevice={onTouchDevice}
-          takeTour={() => {
-            setPinned(false);
-            setShowing(false);
-            setProductTourMode("intro");
-          }}
-        />
-      </div>
+      {productTourMode === "finished" && (
+        <>
+          <HelpButton
+            onClick={() => setShowing(true)}
+            onTouchDevice={onTouchDevice}
+          />
+          <InstructionsModal
+            showing={show}
+            setShowing={setShowing}
+            pinned={pinned}
+            setPinned={setPinned}
+            onTouchDevice={onTouchDevice}
+            takeTour={() => {
+              setPinned(false);
+              setShowing(false);
+              setProductTourMode("intro");
+            }}
+          />
+        </>
+      )}
 
       <ProductTour
         productTourMode={productTourMode}

--- a/src/components/HelpButton/HelpButton.tsx
+++ b/src/components/HelpButton/HelpButton.tsx
@@ -1,0 +1,28 @@
+import classes from "./helpButton.module.scss";
+import { cn } from "@/lib/utils";
+
+type HelpButtonProps = {
+  onClick: () => void;
+  onTouchDevice: boolean;
+};
+
+/**
+ * A floating help button that opens the instructions modal.
+ */
+const HelpButton = ({ onClick, onTouchDevice }: HelpButtonProps) => {
+  return (
+    <button
+      className={cn(
+        classes.helpButton,
+        onTouchDevice ? classes.mobile : classes.desktop
+      )}
+      onClick={onClick}
+      aria-label="Open instructions"
+      type="button"
+    >
+      ?
+    </button>
+  );
+};
+
+export default HelpButton;

--- a/src/components/HelpButton/helpButton.module.scss
+++ b/src/components/HelpButton/helpButton.module.scss
@@ -1,0 +1,50 @@
+/* Help button styling */
+.helpButton {
+  position: fixed;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(248, 243, 232, 0.95);
+  border: 2px solid rgba(0, 0, 0, 0.1);
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.15),
+    0 1px 3px rgba(0, 0, 0, 0.1);
+
+  font-size: 28px;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.75);
+
+  cursor: pointer;
+  z-index: 1000;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+
+  &:hover {
+    transform: scale(1.05);
+    background: rgba(248, 243, 232, 1);
+    box-shadow:
+      0 4px 12px rgba(0, 0, 0, 0.2),
+      0 2px 4px rgba(0, 0, 0, 0.15);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+
+  &.desktop {
+    bottom: 2rem;
+    left: 2rem;
+  }
+
+  &.mobile {
+    bottom: 1.5rem;
+    right: 1.5rem;
+  }
+}

--- a/src/components/InstructionsPaper/InstructionsModal.tsx
+++ b/src/components/InstructionsPaper/InstructionsModal.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from "react";
+import InstructionsPaper from "./InstructionsPaper";
+import classes from "./instructionsModal.module.scss";
+import { cn } from "@/lib/utils";
+import type { Dispatch, SetStateAction } from "react";
+
+type InstructionsModalProps = {
+  showing: boolean;
+  setShowing: Dispatch<SetStateAction<boolean>>;
+  pinned: boolean;
+  setPinned: Dispatch<SetStateAction<boolean>>;
+  takeTour: () => void;
+  onTouchDevice: boolean;
+};
+
+/**
+ * Modal wrapper for the instructions paper.
+ * Shows the paper in a centered modal overlay.
+ */
+const InstructionsModal = ({
+  showing,
+  setShowing,
+  pinned,
+  setPinned,
+  takeTour,
+  onTouchDevice,
+}: InstructionsModalProps) => {
+  // Lock body scroll when modal is open
+  useEffect(() => {
+    if (showing) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [showing]);
+
+  // Close on escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && showing) {
+        setShowing(false);
+        setPinned(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [showing, setShowing, setPinned]);
+
+  if (!showing) return null;
+
+  return (
+    <div
+      className={classes.modalOverlay}
+      onClick={() => {
+        setShowing(false);
+        setPinned(false);
+      }}
+    >
+      <div
+        className={classes.modalContent}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <InstructionsPaper
+          tilt={{ x: 0, y: 0 }}
+          showing={showing}
+          setShowing={setShowing}
+          pinned={pinned}
+          setPinned={setPinned}
+          takeTour={takeTour}
+          onTouchDevice={onTouchDevice}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default InstructionsModal;

--- a/src/components/InstructionsPaper/InstructionsPaper.tsx
+++ b/src/components/InstructionsPaper/InstructionsPaper.tsx
@@ -35,52 +35,29 @@ const InstructionsPaper = ({
   takeTour,
   onTouchDevice,
 }: InstructionsPaperProps) => {
-  const [open, setOpen] = useState(false);
+  // Always show as open when in modal
+  const [open, setOpen] = useState(true);
 
   return (
     <div
-      className={cn(classes.stage, (pinned || open) && classes.open)}
+      className={cn(classes.stage, classes.open, classes.inModal)}
       style={{
         transform: `rotateX(${y}deg) rotateY(${x}deg)`,
-        width: open ? "312px" : "250px",
-        height: open ? "312px" : "200px",
+        width: "312px",
+        height: "312px",
         color: "rgba(0, 0, 0, 0.75)",
         textShadow: "0 2px 2px rgba(0, 0, 0, 0.1)",
-        ...(!showing && !pinned && onTouchDevice
-          ? {
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
-              marginRight: "8px",
-            }
-          : {}),
       }}
       onClick={(e) => {
         e.stopPropagation();
-
-        setOpen((open) => !open);
-        setShowing((showing) => !showing);
       }}
-      onMouseLeave={
-        !onTouchDevice && open
-          ? (e) => {
-              e.preventDefault();
-              setOpen(false);
-              setShowing(false);
-            }
-          : undefined
-      }
     >
       <div
         className={cn(classes.box, classes.box1)}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-
-          setOpen((open) => !open);
-          setShowing((showing) => !showing);
         }}
-        onMouseEnter={onTouchDevice ? undefined : () => setOpen(true)}
       >
         <div>
           PO-12 rhythm

--- a/src/components/InstructionsPaper/instructionsModal.module.scss
+++ b/src/components/InstructionsPaper/instructionsModal.module.scss
@@ -1,0 +1,58 @@
+/* Modal overlay and content */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  z-index: 998;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 1rem;
+
+  animation: fadeIn 0.2s ease;
+}
+
+.modalContent {
+  position: relative;
+  max-width: 100%;
+  max-height: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  animation: slideUp 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Mobile optimizations */
+@media (pointer: coarse) {
+  .modalOverlay {
+    padding: 0.5rem;
+  }
+}

--- a/src/components/InstructionsPaper/instructionsPaper.module.scss
+++ b/src/components/InstructionsPaper/instructionsPaper.module.scss
@@ -24,6 +24,13 @@ $cardBorderRadius: 1px;
   padding-top: 30px;
 }
 
+/* When in modal, remove problematic positioning */
+.inModal {
+  margin-top: 0;
+  padding-top: 0;
+  position: relative;
+}
+
 .open {
   @extend .cardBoxShadow;
   transition-delay: calc(#{$foldSpeed} * 2);


### PR DESCRIPTION
Adds a floating help button that opens the manual once the tour is done. Moves the instructions paper into a modal with scroll lock and keyboard dismissal. Simplifies the paper component styling for modal use. Tested locally in the browser.