### PR TITLE
Condense instructions modal

### DIFF
--- a/src/components/HelpButton/helpButton.module.scss
+++ b/src/components/HelpButton/helpButton.module.scss
@@ -1,8 +1,8 @@
 /* Help button styling */
 .helpButton {
   position: fixed;
-  width: 56px;
-  height: 56px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
   background: rgba(248, 243, 232, 0.95);
   border: 2px solid rgba(0, 0, 0, 0.1);
@@ -10,7 +10,7 @@
     0 2px 8px rgba(0, 0, 0, 0.15),
     0 1px 3px rgba(0, 0, 0, 0.1);
 
-  font-size: 28px;
+  font-size: 22px;
   font-weight: 600;
   color: rgba(0, 0, 0, 0.75);
 
@@ -44,7 +44,18 @@
   }
 
   &.mobile {
-    bottom: 1.5rem;
-    right: 1.5rem;
+    bottom: 1rem;
+    right: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    width: 56px;
+    height: 56px;
+    font-size: 28px;
+
+    &.mobile {
+      bottom: 1.5rem;
+      right: 1.5rem;
+    }
   }
 }

--- a/src/components/InstructionsPaper/InstructionsPaper.tsx
+++ b/src/components/InstructionsPaper/InstructionsPaper.tsx
@@ -1,7 +1,6 @@
 import classes from "./instructionsPaper.module.scss";
 import {
   OneButtonIcon,
-  SixteenButtonIcon,
   DotgridIcon,
   SCurveIcon,
   MetronomeIcon,
@@ -23,6 +22,35 @@ const InstructionsPaper = ({
   setShowing,
   takeTour,
 }: InstructionsPaperProps) => {
+  const panelControls = [
+    { icon: <OneButtonIcon />, label: "note trig", detail: "1-16" },
+    { icon: <DotgridIcon />, label: "pattern", detail: "select bank" },
+    { icon: <SCurveIcon />, label: "sound", detail: "swap voice" },
+    { icon: <MetronomeIcon />, label: "bpm", detail: "tempo + swing" },
+    { icon: <RecordIcon />, label: "record", detail: "hold + trig" },
+    { icon: <PlayIcon />, label: "play", detail: "transport" },
+  ];
+
+  const controlShortcuts = [
+    { icon: <SCurveIcon />, label: "sound", key: "j" },
+    { icon: <DotgridIcon />, label: "pattern", key: "k" },
+    { icon: <MetronomeIcon />, label: "bpm", key: "l" },
+    { icon: <RecordIcon />, label: "record", key: "·" },
+    { icon: <PlayIcon />, label: "play", key: "⎵" },
+  ];
+
+  const transferShortcuts = [
+    { label: "import pattern", key: "]" },
+    { label: "export pattern", key: "[" },
+  ];
+
+  const noteRows = [
+    ["1", "2", "3", "4"],
+    ["q", "w", "e", "r"],
+    ["a", "s", "d", "f"],
+    ["z", "x", "c", "v"],
+  ];
+
   return (
     <div className={classes.instructionsContainer}>
       <div className={classes.instructionsHeader}>
@@ -30,106 +58,77 @@ const InstructionsPaper = ({
       </div>
 
       <div className={classes.instructionsContent}>
-        <section className={classes.instructionsSection}>
-          <h3>Controls</h3>
-          <ul className={classes.controlsList}>
-            <li>
-              <OneButtonIcon /> - <SixteenButtonIcon />: play note
-            </li>
-            <li>
-              <DotgridIcon />: choose pattern
-            </li>
-            <li>
-              <SCurveIcon />: choose sound
-            </li>
-            <li>
-              <MetronomeIcon />: change bpm
-            </li>
-            <li>
-              <RecordIcon />: record
-            </li>
-            <li>
-              <PlayIcon />: play
-            </li>
-          </ul>
-        </section>
-
-        <section className={classes.instructionsSection}>
-          <h3>Keyboard Shortcuts</h3>
-          <div className={classes.keymapGrid}>
-            <div className={classes.keymapSection}>
-              <h4>Notes</h4>
-              <div className={classes.instructionsPaperKeymap}>
-                <div className={classes.instructionsPaperRow}>
-                  <div className={classes.instructionsPaperCell}>1</div>
-                  <div className={classes.instructionsPaperCell}>2</div>
-                  <div className={classes.instructionsPaperCell}>3</div>
-                  <div className={classes.instructionsPaperCell}>4</div>
-                </div>
-                <div className={classes.instructionsPaperRow}>
-                  <div className={classes.instructionsPaperCell}>q</div>
-                  <div className={classes.instructionsPaperCell}>w</div>
-                  <div className={classes.instructionsPaperCell}>e</div>
-                  <div className={classes.instructionsPaperCell}>r</div>
-                </div>
-                <div className={classes.instructionsPaperRow}>
-                  <div className={classes.instructionsPaperCell}>a</div>
-                  <div className={classes.instructionsPaperCell}>s</div>
-                  <div className={classes.instructionsPaperCell}>d</div>
-                  <div className={classes.instructionsPaperCell}>f</div>
-                </div>
-                <div className={classes.instructionsPaperRow}>
-                  <div className={classes.instructionsPaperCell}>z</div>
-                  <div className={classes.instructionsPaperCell}>x</div>
-                  <div className={classes.instructionsPaperCell}>c</div>
-                  <div className={classes.instructionsPaperCell}>v</div>
-                </div>
-              </div>
+        <div className={classes.instructionsGrid}>
+          <section className={classes.instructionsSection}>
+            <div className={classes.sectionHeading}>
+              <h3>Panel</h3>
+              <span className={classes.sectionMeta}>icon → function</span>
             </div>
+            <ul className={classes.panelGrid}>
+              {panelControls.map(({ icon, label, detail }) => (
+                <li key={label} className={classes.panelItem}>
+                  {icon}
+                  <div className={classes.panelCopy}>
+                    <span>{label}</span>
+                    {detail ? <small>{detail}</small> : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
 
-            <div className={classes.keymapSection}>
-              <h4>Controls</h4>
-              <div className={classes.controlKeymap}>
-                <div className={classes.instructionsPaperRow}>
-                  <SCurveIcon />
-                  {" ↔ "}
-                  <div className={classes.instructionsPaperKey}>j</div>
-                </div>
-                <div className={classes.instructionsPaperRow}>
-                  <DotgridIcon />
-                  {" ↔ "}
-                  <div className={classes.instructionsPaperKey}>k</div>
-                </div>
-                <div className={classes.instructionsPaperRow}>
-                  <MetronomeIcon />
-                  {" ↔ "}
-                  <div className={classes.instructionsPaperKey}>l</div>
-                </div>
-                <div className={classes.instructionsPaperRow}>
-                  <RecordIcon />
-                  {" ↔ "}
-                  <div className={classes.instructionsPaperKey}>&#183;</div>
-                </div>
-                <div className={classes.instructionsPaperRow}>
-                  <PlayIcon />
-                  {" ↔ "}
-                  <div className={classes.instructionsPaperKey}>&#9141;</div>
-                </div>
-              </div>
+          <section className={classes.instructionsSection}>
+            <div className={classes.sectionHeading}>
+              <h3>Ctrl keys</h3>
+              <span className={classes.sectionMeta}>left hand</span>
             </div>
-          </div>
+            <div className={classes.controlShortcuts}>
+              {controlShortcuts.map(({ icon, label, key }) => (
+                <div key={label} className={classes.controlShortcut}>
+                  {icon}
+                  <div className={classes.shortcutCopy}>
+                    <span>{label}</span>
+                    <div className={classes.instructionsPaperKey}>{key}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className={classes.utilityShortcuts}>
+              {transferShortcuts.map(({ label, key }) => (
+                <div key={label} className={classes.utilityShortcut}>
+                  <span>{label}</span>
+                  <span className={classes.utilityKey}>{key}</span>
+                </div>
+              ))}
+            </div>
+          </section>
 
-          <div className={classes.importExportHint}>
-            <span>] import</span>
-            <span>export [→</span>
-          </div>
-        </section>
+          <section className={classes.instructionsSection}>
+            <div className={classes.sectionHeading}>
+              <h3>Note grid</h3>
+              <span className={classes.sectionMeta}>mirrors keypad</span>
+            </div>
+            <div className={classes.instructionsPaperKeymap}>
+              {noteRows.map((row, rowIndex) => (
+                <div key={`note-row-${rowIndex}`} className={classes.instructionsPaperRow}>
+                  {row.map((key) => (
+                    <div key={key} className={classes.instructionsPaperCell}>
+                      {key}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
 
-        <section className={classes.instructionsSection}>
-          <h3>About</h3>
+        <section className={`${classes.instructionsSection} ${classes.aboutSection}`}>
+          <div className={classes.sectionHeading}>
+            <h3>About</h3>
+            <span className={classes.sectionMeta}>credits</span>
+          </div>
           <p className={classes.disclaimer}>
-            This is an unlicensed partial reimplementation of a hardware device.
-            All design credit goes to Teenage Engineering.
+            Tribute interface for PO-12 rhythm. Teenage Engineering owns the original hardware + art.
           </p>
           <div className={classes.links}>
             <a
@@ -137,26 +136,21 @@ const InstructionsPaper = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              Buy original
+              buy original
             </a>
+            <span>•</span>
             <a
               href="https://teenage.engineering/guides/po-12/en"
               target="_blank"
               rel="noopener noreferrer"
             >
-              Full manual
+              full manual
             </a>
-          </div>
-          <p className={classes.attribution}>
-            by{" "}
-            <a
-              href="https://twitter.com/@jakeissnt"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <span>•</span>
+            <a href="https://twitter.com/@jakeissnt" target="_blank" rel="noopener noreferrer">
               @jakeissnt
             </a>
-          </p>
+          </div>
         </section>
       </div>
 

--- a/src/components/InstructionsPaper/instructionsCardButton.module.scss
+++ b/src/components/InstructionsPaper/instructionsCardButton.module.scss
@@ -1,28 +1,29 @@
 .instructionsCardButton {
   border: 1px solid black;
   opacity: 0.6;
-  padding: 6px 8px;
-  border-radius: 3px;
-  min-height: 28px; // Increased for better touch targets
+  padding: 3px 6px;
+  border-radius: 2px;
+  min-height: 22px;
   margin: 0;
-  font-size: 12px;
+  font-size: 10px;
   border-color: black;
-  min-width: 50px;
+  min-width: 42px;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
   cursor: pointer;
   transition: all 0.15s ease-in-out;
   user-select: none;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.1);
+  font-weight: 500;
 
   &:disabled {
     display: none;
   }
 
   &:hover {
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     opacity: 1;
   }
 
@@ -33,10 +34,16 @@
 
   // Better touch targets on mobile
   @media (pointer: coarse) {
-    min-height: 36px;
-    padding: 8px 12px;
-    font-size: 13px;
-    min-width: 60px;
+    min-height: 28px;
+    padding: 5px 8px;
+    font-size: 11px;
+    min-width: 50px;
+  }
+
+  @media (min-width: 640px) {
+    font-size: 11px;
+    min-height: 24px;
+    padding: 4px 7px;
   }
 }
 

--- a/src/components/InstructionsPaper/instructionsPaper.module.scss
+++ b/src/components/InstructionsPaper/instructionsPaper.module.scss
@@ -2,99 +2,45 @@
 $paperBorderColor: #f8f3e8;
 $paperCenterColor: #faf7f0;
 
-/* Simplified instructions container - mobile first, dense like the manual */
+/* Ultra-dense instructions container - maximum information density */
 .instructionsContainer {
   background: $paperCenterColor;
-  border-radius: 0;
+  border-radius: 2px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-  width: 100%;
+  width: clamp(240px, 90vw, 420px);
+  margin: 0 auto;
   max-height: 100vh;
   overflow-y: auto;
   color: rgba(0, 0, 0, 0.85);
+  font-size: 0.6875rem; /* Base font smaller */
+  line-height: 1.2; /* Tighter line height */
 
   /* Desktop gets rounded corners and max-width */
   @media (min-width: 640px) {
-    border-radius: 8px;
-    max-width: 480px;
+    border-radius: 4px;
+    max-width: 420px;
+    width: clamp(320px, 70vw, 420px);
     max-height: 85vh;
+    font-size: 0.75rem;
   }
 
   @media (min-width: 768px) {
-    max-width: 520px;
+    max-width: 450px;
+    width: clamp(360px, 60vw, 450px);
   }
 }
 
 .instructionsHeader {
-  padding: 0.75rem 1rem;
+  padding: 0.375rem 0.625rem;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   background: rgba(255, 255, 255, 0.3);
 
   h2 {
     margin: 0;
-    font-size: 1.0625rem;
-    font-weight: 600;
-    color: rgba(0, 0, 0, 0.85);
-
-    @media (min-width: 640px) {
-      font-size: 1.125rem;
-    }
-  }
-}
-
-.instructionsContent {
-  padding: 1rem;
-
-  @media (min-width: 640px) {
-    padding: 1.125rem;
-  }
-}
-
-.instructionsSection {
-  margin-bottom: 1rem;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-
-  h3 {
-    margin: 0 0 0.5rem 0;
-    font-size: 0.9375rem;
-    font-weight: 600;
-    color: rgba(0, 0, 0, 0.85);
-
-    @media (min-width: 640px) {
-      font-size: 1rem;
-    }
-  }
-
-  h4 {
-    margin: 0 0 0.375rem 0;
-    font-size: 0.625rem;
-    font-weight: 600;
-    color: rgba(0, 0, 0, 0.6);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-}
-
-.controlsList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-
-  li {
-    padding: 0.25rem 0;
     font-size: 0.8125rem;
-    line-height: 1.4;
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-
-    svg {
-      display: inline-block;
-      vertical-align: middle;
-      flex-shrink: 0;
-    }
+    font-weight: 700;
+    color: rgba(0, 0, 0, 0.85);
+    letter-spacing: -0.01em;
 
     @media (min-width: 640px) {
       font-size: 0.875rem;
@@ -102,35 +48,200 @@ $paperCenterColor: #faf7f0;
   }
 }
 
-.keymapGrid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-  margin-bottom: 0.625rem;
+.instructionsContent {
+  padding: 0.45rem 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 
   @media (min-width: 640px) {
-    grid-template-columns: 1fr 1fr;
-    gap: 1.25rem;
+    padding: 0.625rem 0.75rem;
+    gap: 0.45rem;
   }
 }
 
-.keymapSection {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+.instructionsGrid {
+  column-gap: 0.4rem;
+  column-count: 1;
+
+  @media (min-width: 640px) {
+    column-gap: 0.75rem;
+    column-count: 2;
+  }
+
+  @media (min-width: 1024px) {
+    column-count: 3;
+  }
 }
 
-.controlKeymap {
+.instructionsSection {
   display: flex;
   flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.35rem 0.45rem;
+  margin: 0 0 0.35rem;
+  width: 100%;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.4);
+  break-inside: avoid;
+  column-break-inside: avoid;
+  page-break-inside: avoid;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  @media (min-width: 640px) {
+    gap: 0.4rem;
+    margin-bottom: 0.45rem;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    color: rgba(0, 0, 0, 0.85);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+
+    @media (min-width: 640px) {
+      font-size: 0.75rem;
+    }
+  }
+
+  h4 {
+    margin: 0 0 0.1875rem 0;
+    font-size: 0.5625rem;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.55);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}
+
+.aboutSection {
+  margin-bottom: 0;
+}
+
+.sectionHeading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
   gap: 0.25rem;
-  font-size: 0.8125rem;
+}
+
+.sectionMeta {
+  font-size: 0.5625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.panelGrid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.25rem;
+}
+
+.panelItem {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+  font-size: 0.6875rem;
+  line-height: 1.2;
+  color: rgba(0, 0, 0, 0.8);
+
+  svg {
+    display: inline-block;
+    vertical-align: middle;
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+  }
+
+  @media (min-width: 640px) {
+    font-size: 0.75rem;
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+}
+
+.panelCopy {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+
+  small {
+    font-size: 0.5625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: rgba(0, 0, 0, 0.45);
+  }
+}
+
+.controlShortcuts {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.controlShortcut {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.6875rem;
+  color: rgba(0, 0, 0, 0.8);
+
+  @media (min-width: 640px) {
+    font-size: 0.75rem;
+  }
+}
+
+.shortcutCopy {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 0.25rem;
+}
+
+.utilityShortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  padding-top: 0.25rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.utilityShortcut {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.5625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(0, 0, 0, 0.55);
+  padding: 0.125rem 0.25rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.45);
+}
+
+.utilityKey {
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.7);
 }
 
 .instructionsPaperKeymap {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.1rem;
   align-items: center;
 }
 
@@ -138,11 +249,18 @@ $paperCenterColor: #faf7f0;
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.1rem;
 
   svg {
     display: inline-block;
     flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+
+    @media (min-width: 640px) {
+      width: 16px;
+      height: 16px;
+    }
   }
 }
 
@@ -151,17 +269,18 @@ $paperCenterColor: #faf7f0;
   align-items: center;
   justify-content: center;
   border: 1px solid rgba(0, 0, 0, 0.3);
-  width: 26px;
-  height: 26px;
-  border-radius: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 1px;
   text-align: center;
-  font-size: 0.8125rem;
+  font-size: 0.6875rem;
   background: rgba(255, 255, 255, 0.5);
+  font-weight: 500;
 
   @media (min-width: 640px) {
-    width: 28px;
-    height: 28px;
-    font-size: 0.875rem;
+    width: 20px;
+    height: 20px;
+    font-size: 0.75rem;
   }
 }
 
@@ -170,54 +289,50 @@ $paperCenterColor: #faf7f0;
   align-items: center;
   justify-content: center;
   border: 1px solid rgba(0, 0, 0, 0.3);
-  min-width: 26px;
-  height: 26px;
-  padding: 0 0.375rem;
-  border-radius: 3px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 0.25rem;
+  border-radius: 1px;
   text-align: center;
-  font-size: 0.8125rem;
+  font-size: 0.6875rem;
   background: rgba(255, 255, 255, 0.5);
+  font-weight: 500;
 
   @media (min-width: 640px) {
-    min-width: 28px;
-    height: 28px;
-    font-size: 0.875rem;
+    min-width: 22px;
+    height: 22px;
+    font-size: 0.75rem;
   }
 }
 
-.importExportHint {
-  display: flex;
-  justify-content: space-between;
-  padding: 0.5rem 0;
-  margin-top: 0.625rem;
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
-  font-size: 0.75rem;
-  color: rgba(0, 0, 0, 0.6);
-}
-
 .disclaimer {
-  font-size: 0.75rem;
-  line-height: 1.4;
+  font-size: 0.625rem;
+  line-height: 1.3;
   color: rgba(0, 0, 0, 0.7);
-  margin: 0 0 0.625rem 0;
+  margin: 0 0 0.3125rem 0;
+
+  @media (min-width: 640px) {
+    font-size: 0.6875rem;
+  }
 }
 
 .links {
   display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-  margin-bottom: 0.625rem;
-
-  @media (min-width: 640px) {
-    flex-direction: row;
-    gap: 1rem;
-  }
+  flex-direction: row;
+  gap: 0.5rem;
+  margin-bottom: 0.3125rem;
+  flex-wrap: wrap;
 
   a {
     color: rgb(107, 114, 128);
     text-decoration: none;
-    font-size: 0.75rem;
+    font-size: 0.625rem;
     transition: color 0.2s ease;
+    white-space: nowrap;
+
+    @media (min-width: 640px) {
+      font-size: 0.6875rem;
+    }
 
     &:hover {
       color: rgb(75, 85, 99);
@@ -227,9 +342,14 @@ $paperCenterColor: #faf7f0;
 }
 
 .attribution {
-  font-size: 0.75rem;
+  font-size: 0.625rem;
   color: rgba(0, 0, 0, 0.6);
   margin: 0;
+  line-height: 1.2;
+
+  @media (min-width: 640px) {
+    font-size: 0.6875rem;
+  }
 
   a {
     color: rgb(107, 114, 128);
@@ -244,16 +364,16 @@ $paperCenterColor: #faf7f0;
 }
 
 .instructionsFooter {
-  padding: 0.625rem 1rem;
+  padding: 0.375rem 0.625rem;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   background: rgba(255, 255, 255, 0.3);
   display: flex;
-  gap: 0.5rem;
+  gap: 0.375rem;
   justify-content: flex-end;
   flex-wrap: wrap;
 
   @media (min-width: 640px) {
-    padding: 0.75rem 1.125rem;
+    padding: 0.4375rem 0.75rem;
   }
 }
 


### PR DESCRIPTION
Rebuilt the instructions modal into data-driven cards with a masonry layout for higher information density. Tweaked the SCSS to control spacing, clamp widths on small screens, and pin the About section across the bottom. Reduced the floating help button on mobile so it no longer overlaps the dialog.