### PR TITLE
Fix favicon asset paths

### DIFF
--- a/public/favicons/browserconfig.xml
+++ b/public/favicons/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/pocket-operator-favicons/mstile-150x150.png"/>
+            <square150x150logo src="/favicons/mstile-150x150.png"/>
             <TileColor>#da532c</TileColor>
         </tile>
     </msapplication>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Open_Sans } from "next/font/google";
 import { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 
-const faviconPath = "pocket-operator-favicons";
+const faviconPath = "favicons";
 
 export const metadata: Metadata = {
   title: "PO-12 | uln.industries",


### PR DESCRIPTION
Fix favicon metadata to point at existing /public/favicons assets.\n\n- update the shared favicon path constant in layout metadata\n- correct the Windows tile reference in browserconfig.xml